### PR TITLE
[#75318016] Added EpcExample, separated Client, moved StockResponse

### DIFF
--- a/java/examples/erparticle/src/main/java/com/nedap/retail/services/examples/App.java
+++ b/java/examples/erparticle/src/main/java/com/nedap/retail/services/examples/App.java
@@ -1,4 +1,4 @@
-package com.nedap.retail.services.examples.erparticle;
+package com.nedap.retail.services.examples;
 
 import java.io.IOException;
 import java.util.Scanner;

--- a/java/examples/erparticle/src/main/java/com/nedap/retail/services/examples/ArticleExample.java
+++ b/java/examples/erparticle/src/main/java/com/nedap/retail/services/examples/ArticleExample.java
@@ -1,4 +1,4 @@
-package com.nedap.retail.services.examples.erparticle;
+package com.nedap.retail.services.examples;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/java/examples/erparticle/src/main/java/com/nedap/retail/services/examples/EpcExample.java
+++ b/java/examples/erparticle/src/main/java/com/nedap/retail/services/examples/EpcExample.java
@@ -1,0 +1,35 @@
+package com.nedap.retail.services.examples;
+
+import com.nedap.retail.messages.Client;
+import com.nedap.retail.messages.epc.v2.difference_list.DifferenceListResponse;
+import com.nedap.retail.messages.epc.v2.stock.StockResponse;
+import com.sun.jersey.api.client.UniformInterfaceException;
+
+public class EpcExample {
+
+    public static void runExample(final Client client) {
+        System.out.println("-------------");
+        System.out.println("EPC API example");
+        System.out.println("-------------");
+
+        final String location = "http://location-testing";
+
+        try {
+            // get difference list
+            System.out.println("------------- Retrieving difference list");
+            final DifferenceListResponse dl = client.differenceList("12345678901231", null, null, null);
+            System.out.println(dl.toString());
+
+            // get stock gtin
+            System.out.println("------------- Retrieving stock gtin");
+            final StockResponse sg = client.stockGtin(location, null, null, null, null);
+            System.out.println(sg.toString());
+
+        } catch (final UniformInterfaceException e) {
+            System.out.println("Server responded with an error:");
+            System.out.println(e.getResponse().getEntity(String.class));
+        }
+
+        System.out.println("------------- Done");
+    }
+}

--- a/java/examples/erparticle/src/main/java/com/nedap/retail/services/examples/ErpExample.java
+++ b/java/examples/erparticle/src/main/java/com/nedap/retail/services/examples/ErpExample.java
@@ -1,4 +1,4 @@
-package com.nedap.retail.services.examples.erparticle;
+package com.nedap.retail.services.examples;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/java/messages/pom.xml
+++ b/java/messages/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.nedap.retail.services</groupId>
     <artifactId>messages</artifactId>
-    <version>1.24</version>
+    <version>1.25</version>
 
     <name>Nedap Retail Api Client</name>
     <packaging>jar</packaging>

--- a/java/messages/src/main/java/com/nedap/retail/messages/Client.java
+++ b/java/messages/src/main/java/com/nedap/retail/messages/Client.java
@@ -4,7 +4,6 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import org.codehaus.jackson.jaxrs.Annotations;
 import org.codehaus.jackson.jaxrs.JacksonJsonProvider;
@@ -16,10 +15,8 @@ import org.slf4j.LoggerFactory;
 
 import com.nedap.retail.messages.article.Article;
 import com.nedap.retail.messages.article.Articles;
-import com.nedap.retail.messages.epc.v2.approved_difference_list.ExportStatus;
-import com.nedap.retail.messages.epc.v2.approved_difference_list.request.ApprovedDifferenceListExportStatusUpdateRequest;
-import com.nedap.retail.messages.epc.v2.approved_difference_list.response.ApprovedDifferenceListResponse;
 import com.nedap.retail.messages.epc.v2.difference_list.DifferenceListResponse;
+import com.nedap.retail.messages.epc.v2.stock.StockResponse;
 import com.nedap.retail.messages.organization.Location;
 import com.nedap.retail.messages.organization.Organizations;
 import com.nedap.retail.messages.stock.Stock;
@@ -39,8 +36,6 @@ import com.sun.jersey.api.client.config.DefaultClientConfig;
  */
 public class Client {
 
-    private static final String ORGANIZATION_ID = "organization_id";
-    private static final String USER_ID = "user_id";
     private static final Logger logger = LoggerFactory.getLogger(Client.class);
     private final String url;
     private final com.sun.jersey.api.client.Client httpClient;
@@ -103,6 +98,42 @@ public class Client {
     }
 
     /**
+     * To update a system to a new firmware version, you need to know which updates are available for the system. This
+     * could depend on the current firmware version, or on the installed hardware.
+     *
+     * @param systemId Identifies the system.
+     * @return List of fimware versions available for upgrade.
+     */
+    public List<String> getFirmwareList(final String systemId) {
+
+        final WebResource resource = resource("/system/1.0/firmware_versions").queryParam("system_id", systemId);
+        return get(resource, new GenericType<List<String>>() {
+        });
+    }
+
+    /**
+     * This request triggers the firmware update mechanism on a system. This starts a download and installation of the
+     * firmware. During download and installation, the system remains fully functional. After installation, the system
+     * is restarted. Depending on the speed of the internet connection, the number of changes in the firmware and the
+     * number of devices within the system, the update can take up to one hour. Installing a firmware version that is
+     * older than the currently installed version is not possible. Systems that do not run an officially released
+     * firmware version can not be upgraded this way. Official firmware versions have a version number in the form of
+     * year.weeknumber (for example, 13.21).
+     *
+     * You can check if the firmware update succeeded by requesting the status of the system regularly, for example
+     * every 5 minutes after sending the request.
+     *
+     * @param systemId Identifies the system to be upgraded.
+     * @param firmwareVersion Requested firmware version to upgrade to.
+     */
+    public void triggerFirmwareUpgrade(final String systemId, final String firmwareVersion) {
+
+        final WebResource resource = resource("/system/1.0/update").queryParam("system_id", systemId).queryParam(
+                "firmware_version", firmwareVersion);
+        post(resource);
+    }
+
+    /**
      * ERP API: capture stock
      *
      * @param stock Stock entry to capture
@@ -123,74 +154,11 @@ public class Client {
      */
     public Stock retrieveErpStock(final String id) {
 
-        final WebResource resource = resource("/erp/v1/stock.retrieve")
-                .queryParam("id", id);
+        final WebResource resource = resource("/erp/v1/stock.retrieve").queryParam("id", id);
 
         System.out.println(resource.accept(APPLICATION_JSON_TYPE).get(String.class));
 
         return get(resource, Stock.class);
-    }
-
-    /**
-     * @param organizationId Id of organization for difference list
-     * @param erpStockId Id of stock imported from ERP
-     * @param rfidTime Time of RFID cycle count
-     * @param onlyDifferences Boolean to switch between showing only differences or whole list
-     * 
-     * @return list of differences without article information for performance reasons
-     */
-    public DifferenceListResponse differenceList(final long organizationId, final String erpStockId, final DateTime rfidTime,
-            final boolean onlyDifferences) {
-
-        WebResource resource = resource("/epc/v2/difference_list").queryParam("erp_stock_id", erpStockId)
-                .queryParam("include_articles", "false").queryParam(ORGANIZATION_ID, Long.toString(organizationId));
-
-        if (rfidTime != null) {
-            resource = resource.queryParam("time", rfidTime.toString());
-        }
-        // Only differences is by default true
-        if (!onlyDifferences) {
-            resource = resource.queryParam("only_differences", "false");
-        }
-
-        return get(resource, DifferenceListResponse.class);
-    }
-
-    /**
-     * @param organizationId Id of organization for approved difference list
-     * @param approvedDifferenceListId Id approved difference list
-     * 
-     * @return Approved difference list with provided id
-     */
-    public ApprovedDifferenceListResponse approvedDifferenceList(final long organizationId,
-            final String approvedDifferenceListId) {
-
-        if (approvedDifferenceListId == null) {
-            throw new IllegalArgumentException("Approved difference list id is required");
-        }
-
-        final WebResource resource = resource("/epc/v2/approved_difference_list.retrieve").queryParam("id",
-                approvedDifferenceListId).queryParam(ORGANIZATION_ID, Long.toString(organizationId));
-
-        return get(resource, ApprovedDifferenceListResponse.class);
-    }
-
-    /**
-     * @param organizationId Id of organization for approved difference list
-     * @param approvedDifferenceListId Id approved difference list
-     * @param exportStatus Export status for approved difference list
-     */
-    public void updateExportStatus(final long organizationId, final String approvedDifferenceListId,
-            final ExportStatus exportStatus) {
-
-        final WebResource resource = resource("/epc/v2/approved_difference_list.export_status").queryParam(
-                ORGANIZATION_ID, Long.toString(organizationId));
-
-        final ApprovedDifferenceListExportStatusUpdateRequest request = new ApprovedDifferenceListExportStatusUpdateRequest();
-        request.exportStatus = exportStatus;
-        request.id = UUID.fromString(approvedDifferenceListId);
-        post(resource, request);
-
     }
 
     /**
@@ -201,8 +169,7 @@ public class Client {
      */
     public StockSummary getErpStockStatus(final String id) {
 
-        final WebResource resource = resource("/erp/v1/stock.status")
-                .queryParam("id", id);
+        final WebResource resource = resource("/erp/v1/stock.status").queryParam("id", id);
         return get(resource, StockSummary.class);
     }
 
@@ -214,32 +181,7 @@ public class Client {
      */
     public List<StockSummary> getErpStockList(final String location) {
 
-        final WebResource resource = resource("/erp/v1/stock.list")
-                .queryParam("location", location);
-        return get(resource, new GenericType<List<StockSummary>>() {
-        });
-    }
-
-    /**
-     * @param organizationId Id of organization for rfid stock list
-     * @param locationId Location identifier
-     * @param fromRfidTime Lower boundary for rfid stock time
-     * @param untilRfidTime Upper boundary for rfid stock time
-     * @return List of summaries for rfid stock on requested location
-     */
-    public List<StockSummary> getRfidStockList(final long organizationId, final String locationId,
-            final DateTime fromRfidTime, final DateTime untilRfidTime) {
-
-        WebResource resource = resource("/epc/v2/stock.list").queryParam("location", locationId).queryParam(
-                ORGANIZATION_ID, Long.toString(organizationId));
-
-        if (fromRfidTime != null) {
-            resource = resource.queryParam("from_event_time", fromRfidTime.toString());
-        }
-        if (untilRfidTime != null) {
-            resource = resource.queryParam("until_event_time", untilRfidTime.toString());
-        }
-
+        final WebResource resource = resource("/erp/v1/stock.list").queryParam("location", location);
         return get(resource, new GenericType<List<StockSummary>>() {
         });
     }
@@ -253,6 +195,54 @@ public class Client {
 
         final WebResource resource = resource("/article/v2/create_or_replace");
         post(resource, new Articles(articles));
+    }
+
+    public DifferenceListResponse differenceList(final String erpStockId, final DateTime rfidTime,
+            final Boolean onlyDifferences, final Boolean includeArticles) {
+
+        WebResource resource = resource("/epc/v2/difference_list").queryParam("erp_stock_id", erpStockId);
+
+        if (rfidTime != null) {
+            resource = resource.queryParam("time", rfidTime.toString());
+        }
+
+        if (onlyDifferences != null) {
+            resource = resource.queryParam("only_differences", onlyDifferences.toString());
+        }
+
+        if (includeArticles != null) {
+            resource = resource.queryParam("include_articles", includeArticles.toString());
+        }
+
+        return get(resource, DifferenceListResponse.class);
+    }
+
+    public StockResponse stockGtin(final String location, final List<String> gtins,
+            final List<String> dispositions, final DateTime time, final Boolean includeArticles) {
+
+        WebResource resource = resource("/epc/v3/stock.gtin14").queryParam("location", location);
+
+        if (gtins != null) {
+            for (final String gtin : gtins) {
+                resource = resource.queryParam("gtins[]", gtin);
+            }
+        }
+
+        if (dispositions != null) {
+            for (final String disposition : dispositions) {
+                resource = resource.queryParam("dispositions[]", disposition);
+            }
+        }
+
+        if (time != null) {
+            resource = resource.queryParam("time", time.toString());
+        }
+
+        if (includeArticles != null) {
+            resource = resource.queryParam("include_articles", includeArticles.toString());
+        }
+
+        return get(resource, StockResponse.class);
     }
 
     /**
@@ -290,110 +280,13 @@ public class Client {
     }
 
     /**
-     * Retrieves list of sites for given Organization ID and User ID.
-     *
-     * Note that:
-     * - The Organization ID must matched one of the Organization ID for which the access token is authorized.
-     * If not the request will be rejected.
-     * - When access token has User ID associated, the server will use the access token User ID
-     * (and thus ignore the supplied User ID parameter).
-     *
-     * @param organizationId Organization ID.
-     * @param userId User ID.
-     * @return List of sites.
-     */
-    public List<Location> getSites(final long organizationId, final String userId) {
-
-        WebResource resource = resource("/organization/v1/sites").
-                queryParam(ORGANIZATION_ID, Long.toString(organizationId));
-        if (userId != null) {
-            resource = resource.queryParam(USER_ID, userId);
-        }
-
-        return getLocations(resource);
-    }
-
-    /**
-     * Retrieves one location object for the given Organization ID, User ID, and locationId.
-     *
-     * If location object is of type "SITE", it will also include the "children" having all (direct) sub-locations for
-     * that site.
-     *
-     * @param organizationId
-     * @param userId
-     * @param locationId
-     * @return Location
-     */
-    public Location getLocation(final long organizationId, final String userId, final String locationId)
-            throws UniformInterfaceException {
-        if (locationId == null) {
-            throw new IllegalArgumentException("location_id is required");
-        }
-
-        WebResource resource = resource("/organization/v1/location");
-
-        resource = resource.queryParam(ORGANIZATION_ID, Long.toString(organizationId))
-                .queryParam("id", locationId);
-        if (userId != null) {
-            resource = resource.queryParam(USER_ID, userId);
-        }
-
-        return get(resource, Location.class);
-    }
-
-    /**
-     * To update a system to a new firmware version, you need to know which
-     * updates are available for the system. This could depend on the current
-     * firmware version, or on the installed hardware.
-     *
-     * @param systemId Identifies the system.
-     * @return List of fimware versions available for upgrade.
-     */
-    public List<String> getFirmwareList(final String systemId) {
-
-        final WebResource resource = resource("/system/1.0/firmware_versions").queryParam("system_id", systemId);
-        return get(resource, new GenericType<List<String>>() {
-        });
-    }
-
-    /**
-     * This request triggers the firmware update mechanism on a system. This
-     * starts a download and installation of the firmware. During download and
-     * installation, the system remains fully functional. After installation,
-     * the system is restarted. Depending on the speed of the internet
-     * connection, the number of changes in the firmware and the number of
-     * devices within the system, the update can take up to one hour. Installing
-     * a firmware version that is older than the currently installed version is
-     * not possible. Systems that do not run an officially released firmware
-     * version can not be upgraded this way. Official firmware versions have a
-     * version number in the form of year.weeknumber (for example, 13.21).
-     *
-     * You can check if the firmware update succeeded by requesting the status
-     * of the system regularly, for example every 5 minutes after sending the
-     * request.
-     *
-     * @param systemId Identifies the system to be upgraded.
-     * @param firmwareVersion Requested firmware version to upgrade to.
-     */
-    public void triggerFirmwareUpgrade(final String systemId, final String firmwareVersion) {
-
-        final WebResource resource = resource("/system/1.0/update").
-                queryParam("system_id", systemId).
-                queryParam("firmware_version", firmwareVersion);
-        post(resource);
-    }
-
-    /**
      * Push API: subscribe.
      */
-    public void subscribe(final String topic, final String callback, final String secret,
-            final int lease_seconds) {
+    public void subscribe(final String topic, final String callback, final String secret, final int lease_seconds) {
 
-        final WebResource resource = resource("/subscription/1.0/subscribe").
-                queryParam("hub.topic", topic).
-                queryParam("hub.callback", callback).
-                queryParam("hub.secret", secret).
-                queryParam("hub.lease_seconds", "" + lease_seconds);
+        final WebResource resource = resource("/subscription/1.0/subscribe").queryParam("hub.topic", topic)
+                .queryParam("hub.callback", callback).queryParam("hub.secret", secret)
+                .queryParam("hub.lease_seconds", "" + lease_seconds);
 
         post(resource);
     }
@@ -418,10 +311,10 @@ public class Client {
     }
 
     /**
-     * Get user profile by user ID.
-     * Endpoint GET /users/1.0/get
+     * Get user profile by user ID. Endpoint GET /users/1.0/get
      *
-     * @param userId The ID of the user to get the profile for. The special value "me" can be used to indicate the authenticated user.
+     * @param userId The ID of the user to get the profile for. The special value "me" can be used to indicate the
+     *            authenticated user.
      * @return User profile. Returns <tt>null</tt> when not found (status code 404).
      */
     public User getUser(final String userId) {
@@ -463,7 +356,7 @@ public class Client {
         return resource.accept(APPLICATION_JSON_TYPE).get(responseClass);
     }
 
-    private static <T> T get(final WebResource resource, final GenericType<T> responseClass)
+    protected static <T> T get(final WebResource resource, final GenericType<T> responseClass)
             throws UniformInterfaceException {
         return resource.accept(APPLICATION_JSON_TYPE).get(responseClass);
     }
@@ -477,8 +370,7 @@ public class Client {
         return resource.accept(APPLICATION_JSON_TYPE).post(responseClass);
     }
 
-    protected static void post(final WebResource resource, final Object requestEntity)
-            throws UniformInterfaceException {
+    protected static void post(final WebResource resource, final Object requestEntity) throws UniformInterfaceException {
         resource.accept(APPLICATION_JSON_TYPE).type(APPLICATION_JSON_TYPE).post(requestEntity);
     }
 

--- a/java/messages/src/main/java/com/nedap/retail/messages/epc/v2/stock/StockLevelSummary.java
+++ b/java/messages/src/main/java/com/nedap/retail/messages/epc/v2/stock/StockLevelSummary.java
@@ -1,0 +1,32 @@
+package com.nedap.retail.messages.epc.v2.stock;
+
+import org.joda.time.DateTime;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class StockLevelSummary {
+    public DateTime generated;
+    @JsonProperty("rfid_stock_time")
+    public DateTime rfidStockTime;
+    @JsonProperty("stock_rooms_quantity")
+    public Integer stockRoomsQuantity;
+    @JsonProperty("sales_floors_quantity")
+    public Integer salesFloorsQuantity;
+    @JsonProperty("store_quantity")
+    public Integer storeQuantity;
+    @JsonProperty("stock_ratio")
+    public Double stockRatio;
+
+    public StockLevelSummary() {
+    }
+
+    public StockLevelSummary(final DateTime generated, final DateTime rfidStockTime, final Integer stockRoomsQuantity,
+            final Integer salesFloorsQuantity, final Integer storeQuantity, final Double stockRatio) {
+        this.generated = generated;
+        this.rfidStockTime = rfidStockTime;
+        this.stockRoomsQuantity = stockRoomsQuantity;
+        this.salesFloorsQuantity = salesFloorsQuantity;
+        this.storeQuantity = storeQuantity;
+        this.stockRatio = stockRatio;
+    }
+}

--- a/java/messages/src/main/java/com/nedap/retail/messages/epc/v2/stock/StockResponse.java
+++ b/java/messages/src/main/java/com/nedap/retail/messages/epc/v2/stock/StockResponse.java
@@ -1,0 +1,40 @@
+package com.nedap.retail.messages.epc.v2.stock;
+
+import java.util.List;
+
+import org.joda.time.DateTime;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.nedap.retail.messages.article.Article;
+
+@JsonInclude(Include.NON_NULL)
+public class StockResponse extends StockLevelSummary {
+
+    public List<String> gtins;
+    public List<String> locations;
+    public List<Integer> quantities;
+    public DateTime time;
+    public List<Article> articles;
+
+    public StockResponse() {
+    }
+
+    public StockResponse(final List<String> gtins, final List<String> locations, final List<Integer> quantities,
+            final DateTime time, final List<Article> articles) {
+        this.gtins = gtins;
+        this.locations = locations;
+        this.quantities = quantities;
+        this.time = time;
+        this.articles = articles;
+    }
+
+    public void setStockLevelSummary(final StockLevelSummary stockLevelSummary) {
+        generated = stockLevelSummary.generated;
+        rfidStockTime = stockLevelSummary.rfidStockTime;
+        stockRoomsQuantity = stockLevelSummary.stockRoomsQuantity;
+        salesFloorsQuantity = stockLevelSummary.salesFloorsQuantity;
+        storeQuantity = stockLevelSummary.storeQuantity;
+        stockRatio = stockLevelSummary.stockRatio;
+    }
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -16,7 +16,7 @@
         <jsersey-version>1.6</jsersey-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <nedap-retail-messages-version>1.24</nedap-retail-messages-version>
+        <nedap-retail-messages-version>1.25</nedap-retail-messages-version>
     </properties>
 
     <scm>


### PR DESCRIPTION
This is step 1 of removing client API calls which should not be in retail-services-API. Plan is to have all branches updated:
<ul>
<li>Removed api calls which are used internally (this PR)</li>
<li>Create `InternalClient` in `retail-commons` (PR to come after this is merged)</li>
<li>Change dependency of `retail-idcloud` and `retail-services` to depend to `InternalClient`</li>
</ul>

In this pull request:
<ul>
<li>Removed unnecessary stuff from `Client` which will be part of `InternalClient`</li>
<li>Created code for EPC examples</li>
<li>Moved stock response from `retail-idcloud` project</li>
<li>Increased version of messages for backward compatibility issues</li>
</ul>

Here is [link](https://github.com/nedap/retail-commons/compare/develop-nmilovanov-internalclient?expand=1) to retail-commons branch with separated internal client