### PR TITLE
[fixes #88602306] Adding missing annotations on articles and fixing arti...

### DIFF
--- a/java/messages/pom.xml
+++ b/java/messages/pom.xml
@@ -40,6 +40,11 @@
             <version>${slf4j-version}</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j-version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-client</artifactId>
             <version>${jsersey-version}</version>
@@ -84,6 +89,12 @@
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.5</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/java/messages/src/main/java/com/nedap/retail/messages/Client.java
+++ b/java/messages/src/main/java/com/nedap/retail/messages/Client.java
@@ -56,7 +56,7 @@ public class Client {
         this.httpClient.addFilter(new AuthorizationClientFilter(accessTokenResolver));
     }
 
-    private static com.sun.jersey.api.client.Client initHttpClient() {
+    protected com.sun.jersey.api.client.Client initHttpClient() {
         mapper = new ObjectMapper().configure(SerializationConfig.Feature.WRITE_DATES_AS_TIMESTAMPS, false);
         // Jackson's MessageBodyReader implementation appears to be more well-behaved than the Jersey JSON one.
         // And also this provider uses our own configured object-mapper.
@@ -255,7 +255,7 @@ public class Client {
      *            omitted: return all fields in Article resource. Repeat key-value for retrieving multiple fields.
      * @return List of articles retrieved.
      */
-    public Articles retrieveArticles(final DateTime updatedAfter, final int skip, final int count,
+    public List<Article> retrieveArticles(final DateTime updatedAfter, final int skip, final int count,
             final List<String> fields) {
         WebResource resource = resource("/article/v2/retrieve");
 
@@ -266,11 +266,14 @@ public class Client {
         resource = resource.queryParam("skip", String.valueOf(skip));
         resource = resource.queryParam("count", String.valueOf(count));
 
-        for (final String field : fields) {
-            resource = resource.queryParam("fields[]", field);
+        if (fields != null) {
+            for (final String field : fields) {
+                resource = resource.queryParam("fields[]", field);
+            }
         }
 
-        return get(resource, Articles.class);
+        return get(resource, new GenericType<List<Article>>() {
+        });
     }
 
     /**

--- a/java/messages/src/main/java/com/nedap/retail/messages/Client.java
+++ b/java/messages/src/main/java/com/nedap/retail/messages/Client.java
@@ -198,7 +198,7 @@ public class Client {
      *            omitted: all fields will be included in the response. Repeat key-value for retrieving multiple fields.
      * @return List of articles retrieved.
      */
-    public Articles articleDetailsByGtins(final List<String> gtins, final List<String> fields) {
+    public List<Article> articleDetailsByGtins(final List<String> gtins, final List<String> fields) {
         WebResource resource = resource("/article/v2/retrieve");
 
         for (final String gtin : gtins) {
@@ -211,7 +211,8 @@ public class Client {
             }
         }
 
-        return get(resource, Articles.class);
+        return get(resource, new GenericType<List<Article>>() {
+        });
     }
 
     /**
@@ -225,7 +226,7 @@ public class Client {
      *            omitted: all fields will be included in the response. Repeat key-value for retrieving multiple fields.
      * @return List of articles retrieved.
      */
-    public Articles articleDetailsByBarcodes(final List<String> barcodes, final List<String> fields) {
+    public List<Article> articleDetailsByBarcodes(final List<String> barcodes, final List<String> fields) {
         WebResource resource = resource("/article/v2/retrieve");
 
         for (final String barcode : barcodes) {
@@ -238,7 +239,8 @@ public class Client {
             }
         }
 
-        return get(resource, Articles.class);
+        return get(resource, new GenericType<List<Article>>() {
+        });
     }
 
     /**

--- a/java/messages/src/main/java/com/nedap/retail/messages/article/Article.java
+++ b/java/messages/src/main/java/com/nedap/retail/messages/article/Article.java
@@ -50,8 +50,10 @@ public class Article implements Serializable {
     private List<Price> prices;
     private Boolean markdown;
     @JsonProperty(LAST_UPDATED)
+    @org.codehaus.jackson.annotate.JsonProperty(LAST_UPDATED)
     public DateTime lastUpdated;
     @JsonIgnore
+    @org.codehaus.jackson.annotate.JsonIgnore
     public UUID lastUpdatedUUID;
 
 
@@ -183,6 +185,8 @@ public class Article implements Serializable {
         return gtin;
     }
 
+    @JsonIgnore
+    @org.codehaus.jackson.annotate.JsonIgnore
     public DateTime getLastUpdated() {
         return lastUpdated;
     }

--- a/java/messages/src/test/java/com/nedap/retail/messages/ClientTest.java
+++ b/java/messages/src/test/java/com/nedap/retail/messages/ClientTest.java
@@ -1,0 +1,184 @@
+package com.nedap.retail.messages;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.ws.rs.core.MediaType;
+
+import org.codehaus.jackson.jaxrs.Annotations;
+import org.codehaus.jackson.jaxrs.JacksonJsonProvider;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.map.SerializationConfig;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.nedap.retail.messages.article.Article;
+import com.sun.jersey.api.client.ClientRequest;
+import com.sun.jersey.api.client.ClientResponse;
+import com.sun.jersey.core.header.InBoundHeaders;
+import com.sun.jersey.spi.MessageBodyWorkers;
+
+public class ClientTest {
+
+    private static final String URL = "http://api.url.com";
+
+    private static com.sun.jersey.api.client.Client mockHttpClient;
+    private static Client client;
+    private static JacksonJsonProvider jacksonJsonProvider;
+
+    @BeforeClass
+    public static void init() {
+        mockHttpClient = mock(com.sun.jersey.api.client.Client.class);
+
+        initTestClient();
+        initJacksonJsonProvider();
+    }
+
+    /**
+     * Fake http client added here so we can mock configuration and test request and response
+     */
+    private static void initTestClient() {
+        client = new Client(URL, "clientid", "secret") {
+            @Override
+            protected com.sun.jersey.api.client.Client initHttpClient() {
+                // get is creating properties and if this is not called we get NPE
+                when(mockHttpClient.getProperties()).thenCallRealMethod();
+                mockHttpClient.getProperties();
+
+                return mockHttpClient;
+            }
+        };
+    }
+
+    private static void initJacksonJsonProvider() {
+        final ObjectMapper mapper = new ObjectMapper().configure(SerializationConfig.Feature.WRITE_DATES_AS_TIMESTAMPS,
+                false);
+        // We use this reader on client so use same for deserialization
+        jacksonJsonProvider = new JacksonJsonProvider(Annotations.JACKSON);
+        jacksonJsonProvider.setMapper(mapper);
+    }
+
+    @Before
+    public void setUp() {
+        reset(mockHttpClient);
+    }
+
+    @Test
+    public void test_retrieve_articles_by_gtin() throws IOException {
+        final String url = URL + "/article/v2/retrieve";
+
+        try (final InputStream is = ClientTest.class.getResourceAsStream("articles.json")) {
+            final ClientResponse clientResponse = createClientResponse(200, is);
+            final ArgumentCaptor<ClientRequest> clientRequestCaptor = ArgumentCaptor.forClass(ClientRequest.class);
+
+            when(mockHttpClient.handle(clientRequestCaptor.capture())).thenReturn(clientResponse);
+            when(mockHttpClient.resource(url)).thenCallRealMethod();
+            when(mockHttpClient.resource(URI.create(url))).thenCallRealMethod();
+
+            final List<String> gtins = Arrays.asList("03327009483366");
+            final List<String> fields = Arrays.asList("code", "name");
+            final List<Article> articles = client.articleDetailsByGtins(gtins, fields);
+
+            // REQUEST TEST
+            final ClientRequest clientRequest = clientRequestCaptor.getValue();
+            assertEquals("GET", clientRequest.getMethod());
+            assertEquals(URI.create(url + "?gtins%5B%5D=03327009483366&fields%5B%5D=code&fields%5B%5D=name"),
+                    clientRequest.getURI());
+
+            // RESPONSE TEST
+            assertEquals(1, articles.size());
+            final Article article = articles.get(0);
+            assertArticle(article);
+        }
+    }
+
+    @Test
+    public void test_retrieve_articles_by_barcode() throws IOException {
+        final String url = URL + "/article/v2/retrieve";
+
+        try (final InputStream is = ClientTest.class.getResourceAsStream("articles.json")) {
+            final ClientResponse clientResponse = createClientResponse(200, is);
+            final ArgumentCaptor<ClientRequest> clientRequestCaptor = ArgumentCaptor.forClass(ClientRequest.class);
+
+            when(mockHttpClient.handle(clientRequestCaptor.capture())).thenReturn(clientResponse);
+            when(mockHttpClient.resource(url)).thenCallRealMethod();
+            when(mockHttpClient.resource(URI.create(url))).thenCallRealMethod();
+
+            final List<String> barcodes = Arrays.asList("3327009483366");
+            final List<String> fields = Arrays.asList("code", "name");
+            final List<Article> articles = client.articleDetailsByBarcodes(barcodes, fields);
+
+            // REQUEST TEST
+            final ClientRequest clientRequest = clientRequestCaptor.getValue();
+            assertEquals("GET", clientRequest.getMethod());
+            assertEquals(URI.create(url + "?barcodes%5B%5D=3327009483366&fields%5B%5D=code&fields%5B%5D=name"),
+                    clientRequest.getURI());
+
+            // RESPONSE TEST
+            assertEquals(1, articles.size());
+            final Article article = articles.get(0);
+            assertArticle(article);
+        }
+    }
+
+    @Test
+    public void test_retrieve_articles_by_skip_count() throws IOException {
+        final String url = URL + "/article/v2/retrieve";
+
+        try (final InputStream is = ClientTest.class.getResourceAsStream("articles.json")) {
+            final ClientResponse clientResponse = createClientResponse(200, is);
+            final ArgumentCaptor<ClientRequest> clientRequestCaptor = ArgumentCaptor.forClass(ClientRequest.class);
+
+            when(mockHttpClient.handle(clientRequestCaptor.capture())).thenReturn(clientResponse);
+            when(mockHttpClient.resource(url)).thenCallRealMethod();
+            when(mockHttpClient.resource(URI.create(url))).thenCallRealMethod();
+
+            final List<Article> articles = client.retrieveArticles(null, 0, 5, null);
+
+            // REQUEST TEST
+            final ClientRequest clientRequest = clientRequestCaptor.getValue();
+            assertEquals("GET", clientRequest.getMethod());
+            assertEquals(URI.create(url + "?skip=0&count=5"),
+                    clientRequest.getURI());
+
+            // RESPONSE TEST
+            assertEquals(1, articles.size());
+            final Article article = articles.get(0);
+            assertArticle(article);
+        }
+    }
+
+    private void assertArticle(final Article article) {
+        assertEquals("03327009483366", article.getGtin());
+        assertEquals("74478-94565", article.getCode());
+        assertEquals("Nedap", article.getBrand());
+        assertEquals("Summer 2014", article.getSeason());
+    }
+
+    @SuppressWarnings("unchecked")
+    private ClientResponse createClientResponse(final int status, final InputStream is) {
+        final InBoundHeaders inHeaders = new InBoundHeaders();
+        inHeaders.add("Content-Type", "application/json");
+        final MessageBodyWorkers messageBodyWorkers = mock(MessageBodyWorkers.class);
+
+        when(
+                messageBodyWorkers.getMessageBodyReader(any(Class.class), any(Type.class), any(Annotation[].class),
+                        eq(MediaType.APPLICATION_JSON_TYPE))).thenReturn(jacksonJsonProvider);
+
+        return new ClientResponse(status, inHeaders, is, messageBodyWorkers);
+    }
+}

--- a/java/messages/src/test/resources/com/nedap/retail/messages/articles.json
+++ b/java/messages/src/test/resources/com/nedap/retail/messages/articles.json
@@ -1,0 +1,45 @@
+[
+  {
+    "gtin": "03327009483366",
+    "barcodes": [
+      {
+        "type": "ean_13",
+        "value": "3327009483366"
+      },
+      {
+        "type": "ean_13",
+        "value": "3327009483427"
+      }
+    ],
+    "code": "74478-94565",
+    "brand": "Nedap",
+    "season": "Summer 2014",
+    "name": "T-shirt short sleeve, v-neck",
+    "option": "T-shirt short sleeve, v-neck, Black",
+    "style": "T-shirt short sleeve, v-neck",
+    "color": "Black",
+    "sizes": [
+      {
+        "region": "NL",
+        "description": "32/34"
+      },
+      {
+        "region": "DE",
+        "description": "33/32"
+      }
+    ],
+    "supplier": "Nedap Retail",
+    "prices": [
+      {
+        "currency": "EUR",
+        "region": "NL",
+        "amount": 32.95
+      },
+      {
+        "currency": "NOK",
+        "region": "NO",
+        "amount": 3000
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Added unit test for client because we had problems to see actual request and response which client puts on wire. This unit test actually addressed couple of errors in our endpoint so think it is good addition and we should cover all endpoint examples with unit tests.

Jersey 2.x has nice JerseyTest class which makes it easy to test http communication with embedded server but until we switch this will work and we can use this to verify that we did not break stuff when we upgrade.

Short explanation of test class:
<ul>
<li>Created test client which is overriding method to init http jersey client with mocked one</li>
<li>Using ClientRequestCaptor to capture and verify request we are making</li>
<li>Using ClientResponse created out of json file to verify if we are receiving response we expect</li>
</ul>