### PR TITLE
[#75318016] Revert workfow model changes cause serializer stopped pickin...

### DIFF
--- a/java/messages/src/main/java/com/nedap/retail/messages/epc/v2/stock/StockLevelSummary.java
+++ b/java/messages/src/main/java/com/nedap/retail/messages/epc/v2/stock/StockLevelSummary.java
@@ -1,5 +1,6 @@
 package com.nedap.retail.messages.epc.v2.stock;
 
+import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.joda.time.DateTime;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -7,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonInclude(Include.NON_NULL)
+@JsonSerialize(include = JsonSerialize.Inclusion.NON_NULL)
 public class StockLevelSummary {
     public DateTime generated;
     @JsonProperty("rfid_stock_time")

--- a/java/messages/src/main/java/com/nedap/retail/messages/workflow/WorkflowEvent.java
+++ b/java/messages/src/main/java/com/nedap/retail/messages/workflow/WorkflowEvent.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.joda.time.DateTime;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -56,6 +57,8 @@ public class WorkflowEvent implements Serializable {
         this.type = type;
     }
 
+    @JsonIgnore
+    @org.codehaus.jackson.annotate.JsonIgnore
     public DateTime getEventTime() {
         return eventTime;
     }
@@ -71,6 +74,8 @@ public class WorkflowEvent implements Serializable {
         this.location = location;
     }
 
+    @JsonIgnore
+    @org.codehaus.jackson.annotate.JsonIgnore
     public Long getEpcCount() {
         return epcCount;
     }
@@ -79,6 +84,8 @@ public class WorkflowEvent implements Serializable {
         this.epcCount = epcCount;
     }
 
+    @JsonIgnore
+    @org.codehaus.jackson.annotate.JsonIgnore
     public List<String> getMessageIds() {
         return messageIds;
     }

--- a/java/messages/src/main/java/com/nedap/retail/messages/workflow/WorkflowEvent.java
+++ b/java/messages/src/main/java/com/nedap/retail/messages/workflow/WorkflowEvent.java
@@ -6,7 +6,6 @@ import java.util.List;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.joda.time.DateTime;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -49,8 +48,6 @@ public class WorkflowEvent implements Serializable {
         this.messageIds = messageIds;
     }
 
-    @JsonIgnore
-    @org.codehaus.jackson.annotate.JsonIgnore
     public String getType() {
         return type;
     }
@@ -59,8 +56,6 @@ public class WorkflowEvent implements Serializable {
         this.type = type;
     }
 
-    @JsonIgnore
-    @org.codehaus.jackson.annotate.JsonIgnore
     public DateTime getEventTime() {
         return eventTime;
     }
@@ -69,8 +64,6 @@ public class WorkflowEvent implements Serializable {
         this.eventTime = eventTime;
     }
 
-    @JsonIgnore
-    @org.codehaus.jackson.annotate.JsonIgnore
     public String getLocation() {
         return location;
     }
@@ -78,8 +71,6 @@ public class WorkflowEvent implements Serializable {
         this.location = location;
     }
 
-    @JsonIgnore
-    @org.codehaus.jackson.annotate.JsonIgnore
     public Long getEpcCount() {
         return epcCount;
     }
@@ -88,8 +79,6 @@ public class WorkflowEvent implements Serializable {
         this.epcCount = epcCount;
     }
 
-    @JsonIgnore
-    @org.codehaus.jackson.annotate.JsonIgnore
     public List<String> getMessageIds() {
         return messageIds;
     }


### PR DESCRIPTION
In previous commit for java examples `@JsonIgnore` annotations were added on getters which caused idcloud build to fail cause serializer could not pass values and nulls were received on other end. This is revert of problematic class.

@bmjansen I remember a while ago that you were adding `@JsonIgnore` annotations not to duplicate fields, I think it is only case when you have combination of `@JsonProperty(MESSAGE_IDS)` and public getter and in that case we should put `@JsonIgnore` on getter, am I right?