### PR TITLE
Master nbozic stock start time

### DIFF
--- a/java/messages/src/main/java/com/nedap/retail/messages/epc/v2/stock/StockLevelSummary.java
+++ b/java/messages/src/main/java/com/nedap/retail/messages/epc/v2/stock/StockLevelSummary.java
@@ -12,6 +12,9 @@ public class StockLevelSummary {
     @JsonProperty("rfid_stock_time")
     public DateTime rfidStockTime;
 
+    @JsonProperty("rfid_stock_start_time")
+    public DateTime rfidStockStartTime;
+
     @JsonProperty("stock_rooms_quantity")
     public Integer stockRoomsQuantity;
 
@@ -27,10 +30,12 @@ public class StockLevelSummary {
     public StockLevelSummary() {
     }
 
-    public StockLevelSummary(final DateTime generated, final DateTime rfidStockTime, final Integer stockRoomsQuantity,
-            final Integer salesFloorsQuantity, final Integer storeQuantity, final Double stockRatio) {
+    public StockLevelSummary(final DateTime generated, final DateTime rfidStockTime, final DateTime rfidStockStartTime,
+            final Integer stockRoomsQuantity, final Integer salesFloorsQuantity, final Integer storeQuantity,
+            final Double stockRatio) {
         this.generated = generated;
         this.rfidStockTime = rfidStockTime;
+        this.rfidStockStartTime = rfidStockStartTime;
         this.stockRoomsQuantity = stockRoomsQuantity;
         this.salesFloorsQuantity = salesFloorsQuantity;
         this.storeQuantity = storeQuantity;

--- a/java/messages/src/main/java/com/nedap/retail/messages/epc/v2/stock/StockResponse.java
+++ b/java/messages/src/main/java/com/nedap/retail/messages/epc/v2/stock/StockResponse.java
@@ -31,6 +31,7 @@ public class StockResponse extends StockLevelSummary {
     public void setStockLevelSummary(final StockLevelSummary stockLevelSummary) {
         generated = stockLevelSummary.generated;
         rfidStockTime = stockLevelSummary.rfidStockTime;
+        rfidStockStartTime = stockLevelSummary.rfidStockStartTime;
         stockRoomsQuantity = stockLevelSummary.stockRoomsQuantity;
         salesFloorsQuantity = stockLevelSummary.salesFloorsQuantity;
         storeQuantity = stockLevelSummary.storeQuantity;

--- a/java/messages/src/main/java/com/nedap/retail/messages/stock/Stock.java
+++ b/java/messages/src/main/java/com/nedap/retail/messages/stock/Stock.java
@@ -27,6 +27,7 @@ public class Stock extends StockSummary {
         super(stockSummary.id, stockSummary.location, stockSummary.eventTime, stockSummary.externRef,
                 stockSummary.status.toString(), stockSummary.quantity, stockSummary.gtinQuantity, stockSummary.inUse,
                 stockSummary.clientIds);
+        this.startTime = stockSummary.startTime;
         this.quantityList = quantityList;
     }
 

--- a/java/messages/src/main/java/com/nedap/retail/messages/stock/StockSummary.java
+++ b/java/messages/src/main/java/com/nedap/retail/messages/stock/StockSummary.java
@@ -19,7 +19,11 @@ public class StockSummary {
     public String location;
 
     @JsonProperty("event_time")
+    // event time is time of last event (end time), will not be changed because of backward compatibility
     public DateTime eventTime;
+
+    @JsonProperty("start_time")
+    public DateTime startTime;
 
     @JsonProperty("extern_ref")
     public String externRef;


### PR DESCRIPTION
Please check [this commit](https://github.com/nedap/retail-idcloud/compare/develop-nbozic-stock-start-time?expand=1) for reasons why this is changed. We want to support start time of stock take in stock summary meta data