### PR TITLE
[#107174376] Simplify dependencies and upgraded jersey to latest

### DIFF
--- a/java/messages/pom.xml
+++ b/java/messages/pom.xml
@@ -14,10 +14,6 @@
     <description>Client and messages for communicating with the Nedap Retail APIs</description>
     <url>http://www.nedap-retail.com/</url>
 
-    <properties>
-        <fasterxml.version>2.3.3</fasterxml.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>junit</groupId>
@@ -39,16 +35,6 @@
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
             <version>${jersey-version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${fasterxml.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>${fasterxml.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -80,11 +66,6 @@
             <artifactId>mockito-all</artifactId>
             <version>1.9.5</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.4</version>
         </dependency>
     </dependencies>
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -29,7 +29,8 @@
     <properties>
         <junit-version>4.12</junit-version>
         <slf4j-version>1.7.12</slf4j-version>
-        <jersey-version>2.19</jersey-version>
+        <jersey-version>2.22.1</jersey-version>
+        <fasterxml.version>2.5.4</fasterxml.version>
         <maven-surefire-version>2.18.1</maven-surefire-version>
         <maven-release-version>2.5.2</maven-release-version>
         <maven-compiler-version>3.3</maven-compiler-version>


### PR DESCRIPTION
No need to add `com.fasterxml.jackson.core` dependencies because that is already done by `jersey-media-json-jackson`.

Upgraded Jersey to latest version (and thus fasterxml)
